### PR TITLE
Fix disappearing stack traces

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -791,7 +791,7 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 	}
 
 	private void setModel(StacktraceModel model) {
-		if  (!viewer.getControl().isDisposed()) {
+		if (!viewer.getControl().isDisposed()) {
 			setViewerInput(model.getRootFork());
 		}
 		List<Pair<String, IAttribute<IQuantity>>> attrList = AttributeSelection.extractAttributes(itemsToShow);


### PR DESCRIPTION
Timing issue when using a completable future for getModelPreparer where certain stack traces (depending how many samples exist) such that stacktrace panel is empty.  This is mainly seen in the various TLAB tabs.

A nice side-effect is that the UI now feels snappier when navigating and stack traces are updated.