### PR TITLE
Fix Method Profiling Settings Persistence

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MethodProfilingPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MethodProfilingPage.java
@@ -353,6 +353,7 @@ public class MethodProfilingPage extends AbstractDataPage {
 		@Override
 		public void saveTo(IWritableState writableState) {
 			PersistableSashForm.saveState(sash, writableState.createChild(SASH_ELEMENT));
+			table.getManager().getSettings().saveState(writableState.createChild(TABLE_ELEMENT));
 			methodFormatter.saveState(writableState.createChild(METHOD_FORMAT_KEY));
 			saveToLocal();
 		}


### PR DESCRIPTION
Changes to column visibility aren't persisted.

As percentage calculations are very expensive with large amounts of samples, it is important to be able to disable the percentage column.