### PR TITLE
Improve stack trace filtering

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCStackTrace.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCStackTrace.java
@@ -106,4 +106,8 @@ public interface IMCStackTrace {
 	 * @return the truncation state
 	 */
 	TruncationState getTruncationState();
+
+	String getStackTraceString();
+
+	void setStackTraceString(String stackTraceString);
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/FormatToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/FormatToolkit.java
@@ -360,25 +360,30 @@ public class FormatToolkit {
 		linePrefix = linePrefix != null ? linePrefix : "at "; //$NON-NLS-1$
 		lineSeparator = lineSeparator != null ? lineSeparator : System.getProperty("line.separator"); //$NON-NLS-1$
 
-		StringBuilder sb = new StringBuilder();
-		if (trace.getFrames() != null && trace.getFrames().size() > 0) {
-			int rowIndex = 0;
-			int count = trace.getFrames().size();
-			for (IMCFrame frame : trace.getFrames()) {
-				IMCMethod method = frame.getMethod();
-				String methodText = Encode.forHtml(getHumanReadable(method, showReturnValue, showReturnValuePackage,
-						showClassName, showClassPackageName, showArguments, showArgumentsPackage));
+		if (trace.getStackTraceString() == null) {
+			StringBuilder sb = new StringBuilder();
+			if (trace.getFrames() != null && trace.getFrames().size() > 0) {
+				int rowIndex = 0;
+				int count = trace.getFrames().size();
+				for (IMCFrame frame : trace.getFrames()) {
+					IMCMethod method = frame.getMethod();
+					String methodText = Encode.forHtml(getHumanReadable(method, showReturnValue, showReturnValuePackage,
+							showClassName, showClassPackageName, showArguments, showArgumentsPackage));
 
-				sb.append(indent).append(linePrefix).append(methodText).append(lineSeparator);
+					sb.append(indent).append(linePrefix).append(methodText).append(lineSeparator);
 
-				if (rowIndex == maximumVisibleStackTraceElements && rowIndex != count - 1) {
-					sb.append(indent).append("..." + lineSeparator); //$NON-NLS-1$
-					return sb.toString();
+					if (rowIndex == maximumVisibleStackTraceElements && rowIndex != count - 1) {
+						sb.append(indent).append("..." + lineSeparator); //$NON-NLS-1$
+						return sb.toString();
+					}
+					rowIndex++;
 				}
-				rowIndex++;
 			}
+
+			trace.setStackTraceString(sb.toString());
 		}
-		return sb.toString();
+
+		return trace.getStackTraceString();
 	}
 
 	/**

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/MCStackTrace.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/MCStackTrace.java
@@ -90,4 +90,16 @@ public class MCStackTrace implements IMCStackTrace {
 		return truncationState.hashCode() + 31 * frames.hashCode();
 	}
 
+	@Override
+	public String getStackTraceString() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void setStackTraceString(String stackTraceString) {
+		// TODO Auto-generated method stub
+
+	}
+
 }

--- a/core/org.openjdk.jmc.flightrecorder/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder/META-INF/MANIFEST.MF
@@ -19,5 +19,6 @@ Export-Package: org.openjdk.jmc.flightrecorder,
  org.openjdk.jmc.flightrecorder.stacktrace.graph,
  org.openjdk.jmc.flightrecorder.stacktrace.messages.internal,
  org.openjdk.jmc.flightrecorder.util
-Require-Bundle: org.openjdk.jmc.common;visibility:=reexport
+Require-Bundle: org.openjdk.jmc.common;visibility:=reexport,
+ com.google.guava;bundle-version="31.0.1"
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder

--- a/core/org.openjdk.jmc.flightrecorder/pom.xml
+++ b/core/org.openjdk.jmc.flightrecorder/pom.xml
@@ -48,5 +48,10 @@
 			<artifactId>common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.0.1-sfdc.6</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -62,6 +62,7 @@ import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.MemberAccessorToolkit;
 import org.openjdk.jmc.flightrecorder.IParserStats.IEventStats;
+import org.openjdk.jmc.flightrecorder.internal.util.InternCacheProvider;
 import org.openjdk.jmc.flightrecorder.parser.IConstantPoolExtension;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator.FrameCategorization;
@@ -244,6 +245,10 @@ public class ParserStats {
 
 		public ConstantItem(String typeName, Object constant) {
 			this.typeName = typeName;
+			if (constant instanceof IMCStackTrace) {
+				constant = InternCacheProvider.INSTANCE.getWeakInterner(IMCStackTrace.class)
+						.intern((IMCStackTrace) constant);
+			}
 			this.constant = constant;
 		}
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.collection.FastAccessNumberMap;
 import org.openjdk.jmc.common.unit.ContentType;
 import org.openjdk.jmc.common.unit.IUnit;
@@ -76,6 +77,7 @@ import org.openjdk.jmc.flightrecorder.internal.parser.v1.ValueReaders.Reflective
 import org.openjdk.jmc.flightrecorder.internal.parser.v1.ValueReaders.StringReader;
 import org.openjdk.jmc.flightrecorder.internal.parser.v1.ValueReaders.StructReader;
 import org.openjdk.jmc.flightrecorder.internal.parser.v1.ValueReaders.TicksTimestampReader;
+import org.openjdk.jmc.flightrecorder.internal.util.InternCacheProvider;
 import org.openjdk.jmc.flightrecorder.internal.util.JfrInternalConstants;
 import org.openjdk.jmc.flightrecorder.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.parser.IEventSink;
@@ -317,7 +319,11 @@ class TypeManager {
 
 		void readEvent(IDataInput input) throws InvalidJfrFileException, IOException {
 			for (int i = 0; i < valueReaders.size(); i++) {
-				reusableStruct[i] = valueReaders.get(i).read(input, false);
+				Object o = valueReaders.get(i).read(input, false);
+				if (o instanceof JfrStackTrace) {
+					o = InternCacheProvider.INSTANCE.getWeakInterner(IMCStackTrace.class).intern((JfrStackTrace) o);
+				}
+				reusableStruct[i] = o;
 			}
 			eventSink.addEvent(reusableStruct);
 		}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/InternCacheProvider.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/InternCacheProvider.java
@@ -1,0 +1,24 @@
+package org.openjdk.jmc.flightrecorder.internal.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+
+public class InternCacheProvider {
+
+	public static final InternCacheProvider INSTANCE = new InternCacheProvider();
+
+	private final Map<Class, Interner> weakInternerCache;
+
+	public InternCacheProvider() {
+		weakInternerCache = new ConcurrentHashMap<>();
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> Interner<T> getWeakInterner(Class<T> clazz) {
+		weakInternerCache.computeIfAbsent(clazz, c -> Interners.<T> newWeakInterner());
+		return weakInternerCache.get(clazz);
+	}
+}

--- a/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/flightrecorder/test/util/MockStacktraceGenerator.java
+++ b/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/flightrecorder/test/util/MockStacktraceGenerator.java
@@ -68,6 +68,18 @@ public class MockStacktraceGenerator {
 			return truncationState;
 		}
 
+		@Override
+		public String getStackTraceString() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public void setStackTraceString(String stackTraceString) {
+			// TODO Auto-generated method stub
+
+		}
+
 	}
 
 	private static class MockFrame implements IMCFrame {

--- a/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
+++ b/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
@@ -32,14 +32,14 @@
    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<?pde version="3.8"?>
-<target name="jmc-target-2023-03" sequenceNumber="47">
+<?pde version="3.8"?><target name="jmc-target-2023-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
             <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
+            <unit id="com.google.guava" version="31.0.1.jre"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -147,6 +147,9 @@
 									<id>io.github.bric3.fireplace:fireplace-swing-animation:${fireplace.version}</id>
 									<source>true</source>
 								</artifact>
+								<artifact>
+									<id>com.google.guava:guava:31.0.1-jre</id>
+								</artifact>
 								<!-- Dependency of fireplace-swing-animation -->
 								<artifact>
 									<id>org.pushing-pixels:radiance-animation:${radiance.version}</id>


### PR DESCRIPTION
1. Cache stack trace strings in the JfrStackTrace objects for quicker string comparisons (still want to find a better way as this bloats the memory)
2. To counteract the memory bloat let's Introduce guava interners to dedupe JfrFrames/JfrStackTraces